### PR TITLE
split string to get line number at start of method

### DIFF
--- a/FlogHighlighter.py
+++ b/FlogHighlighter.py
@@ -31,7 +31,7 @@ class FlogHighlighterCommand(sublime_plugin.TextCommand):
           'error': []
         }
         for note in notes:
-          line = lines[int(note['line']) - 1]
+          line = lines[int(note['line'].split('-')[0]) - 1]
           regions[note['level']].append(line)
 
         self.view.add_regions('flog_highlighter_note', regions['note'], 'string', 'bookmark', sublime.DRAW_OUTLINED)


### PR DESCRIPTION
  * Without these two, I was getting
  ```ruby
  Traceback (most recent call last):
  File "/Users/myaccount/Library/Application Support/Sublime Text 3/Packages/sublime-flog-highlighter/FlogHighlighter.py", line 34, in run
    line = lines[int(note['line']) - 1]
  ValueError: invalid literal for int() with base 10: '260-295'
  ```
	modified:   FlogHighlighter.py